### PR TITLE
Compile on MacOS, which uses the FreeBSD-style sig_t

### DIFF
--- a/rogue/sys_dep.c
+++ b/rogue/sys_dep.c
@@ -18,7 +18,7 @@ tstop ()
    * we can assume that the signals remain set after an interupt.
    */
 
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__APPLE__)
   sig_t SigCont;
 #else /* __FreeBSD__ */
   __sighandler_t   SigCont;


### PR DESCRIPTION
There are many ways to do this, but I went with the simplest, since this was the only issue I found on MacOS (so far).
